### PR TITLE
Add support for any non-Columbia Canvas site

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Canvas **currently does not export student assignment submission times**. That c
 
 This is what we do.
 
+## Dependencies
+
+- Python, with module [requests](https://github.com/kennethreitz/requests) ( + [grequests](https://github.com/kennethreitz/grequests) if using async version)
+
 ## Quick Start
 
 There are two ways to do this. The first **via Canvas API in Python** and the second **via a Chrome Extension that screen scrapes**. Obviously the first is superior, though I coded the second one earlier. The Chrome extension will no longer be updated / maintained.
@@ -29,10 +33,10 @@ And get yourself a new access token. **Copy it down**.
 Now get submission times by running `canvas-panda.py` with the following arguments:
 
 ```bash
-$ python canvas-panda.py <API_KEY> <Course_ID> <Assignment_ID>
+$ python canvas-panda.py [-u <canvas_url>] <API_KEY> <Course_ID> <Assignment_ID>
 ```
 
-You can find the Course ID and Assignment ID from the URL of the assignment: `https://courseworks2.columbia.edu/courses/xxxx/assignments/yyyy` where `xxxx` is the course ID and `yyyy` is the assignment ID.
+You can find the Course ID and Assignment ID from the URL of the assignment: `https://<canvas_url>/courses/xxxx/assignments/yyyy` where `xxxx` is the course ID and `yyyy` is the assignment ID.
 
 The results will be saved in a .csv file these columns:
 

--- a/canvas-panda-async.py
+++ b/canvas-panda-async.py
@@ -16,11 +16,16 @@ parser = argparse.ArgumentParser(
 parser.add_argument('canvas_api_key', metavar='K', type=str,
                     help='Canvas API Key obtained from "settings"')
 parser.add_argument('course_id', metavar='C', type=int,
-                    help='Course ID. e.g. xxxx in https://courseworks2.columbia.edu/courses/xxxx/assignments/yyyy')
+                    help='Course ID. e.g. xxxx in https://<canvas_url>/courses/xxxx/assignments/yyyy')
 parser.add_argument('assignment_id', metavar='A', type=int,
-                    help='Course ID. e.g. yyyy in https://courseworks2.columbia.edu/courses/xxxx/assignments/yyyy')
+                    help='Course ID. e.g. yyyy in https://<canvas_url>/courses/xxxx/assignments/yyyy')
+parser.add_argument('-u', '--canvas_url', type=str,
+                    help='Canvas base URL (default: courseworks2.columbia.edu)')
 
 args = parser.parse_args()
+
+if not args.canvas_url:
+    args.canvas_url = 'courseworks2.columbia.edu'
 
 # logging
 
@@ -36,7 +41,7 @@ logger.info("running %s" % ' '.join(sys.argv))
 
 HEADERS = {'Authorization': 'Bearer ' + args.canvas_api_key}
 
-URL_BASE = 'https://courseworks2.columbia.edu/api/v1/'
+URL_BASE = 'https://' + args.canvas_url + '/api/v1/'
 
 # map functions
 

--- a/canvas-panda.py
+++ b/canvas-panda.py
@@ -15,11 +15,16 @@ parser = argparse.ArgumentParser(
 parser.add_argument('canvas_api_key', metavar='K', type=str,
                     help='Canvas API Key obtained from "settings"')
 parser.add_argument('course_id', metavar='C', type=int,
-                    help='Course ID. e.g. xxxx in https://courseworks2.columbia.edu/courses/xxxx/assignments/yyyy')
+                    help='Course ID. e.g. xxxx in https://<canvas_url>/courses/xxxx/assignments/yyyy')
 parser.add_argument('assignment_id', metavar='A', type=int,
-                    help='Course ID. e.g. yyyy in https://courseworks2.columbia.edu/courses/xxxx/assignments/yyyy')
+                    help='Course ID. e.g. yyyy in https://<canvas_url>/courses/xxxx/assignments/yyyy')
+parser.add_argument('-u', '--canvas_url', type=str,
+                    help='Canvas base URL (default: courseworks2.columbia.edu)')
 
 args = parser.parse_args()
+
+if not args.canvas_url:
+    args.canvas_url = 'courseworks2.columbia.edu'
 
 # logging
 
@@ -35,7 +40,7 @@ logger.info("running %s" % ' '.join(sys.argv))
 
 HEADERS = {'Authorization': 'Bearer ' + args.canvas_api_key}
 
-URL_BASE = 'https://courseworks2.columbia.edu/api/v1/'
+URL_BASE = 'https://' + args.canvas_url + '/api/v1/'
 
 # map functions
 


### PR DESCRIPTION
Love this data scraper - I'm an instructor at another university and I have begun to use this to gather submission time information on my students.

I've extended the script to allow support for any Canvas site hosted anywhere beyond Columbia University (ie. my university). One can simply use the --canvas_url / -u flag to specify a custom base URL. Otherwise, it will default to the Columbia URL.

I've also included a couple of Python dependencies in the readme that I had to install to get your code running.
